### PR TITLE
🪟 Add sliding window iteration mode for datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This project uses various development tools:
 Run the following commands to ensure code quality:
 
 ```
-uv run ruff --fix .
+uv run ruff check --fix .
 uv run mypy scratchgpt
 uv run pytest ./tests/
 ```

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -65,6 +65,7 @@ def create_simple_config() -> ScratchGPTConfig:
         batch_size=32,
         dropout_rate=0.1,
         random_seed=1337,
+        iteration_type="sliding",
     )
 
     return ScratchGPTConfig(architecture=architecture, training=training)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scratchgpt"
-version = "0.4.0"
+version = "0.5.0"
 description = "A small-scale transformer-based language model implemented from scratch in Python."
 authors = [
   { name = "Aleksandr Yeganov", email = "ayeganov@gmail.com"},

--- a/scratchgpt/config.py
+++ b/scratchgpt/config.py
@@ -1,5 +1,5 @@
 import math
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import AfterValidator, Field, model_validator
 from pydantic_settings import (
@@ -69,6 +69,7 @@ class ScratchGPTTraining(BaseSettings):
     dropout_rate: float = 0.2
     random_seed: int = 1337
     splits: SplitType = (0.8, 0.2)
+    iteration_type: Literal["chunking", "sliding"] = "chunking"
 
     model_config = SettingsConfigDict(
         env_prefix="TRAINING_",

--- a/scratchgpt/data/datasource.py
+++ b/scratchgpt/data/datasource.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Literal, Protocol
 
 from scratchgpt.core.types import DictTensorLoader
 from scratchgpt.tokenizer.base_tokenizer import Tokenizer
@@ -19,6 +19,7 @@ class DataSource(Protocol):
         batch_size: int,
         splits: tuple[float, float],
         random_seed: int,
+        iteration_type: Literal["chunking", "sliding"],
     ) -> tuple[DictTensorLoader, DictTensorLoader | None]:
         """
         Processes data and returns train and validation DataLoaders.

--- a/scratchgpt/training/trainer.py
+++ b/scratchgpt/training/trainer.py
@@ -83,6 +83,7 @@ class Trainer:
             batch_size=self.config.batch_size,
             splits=self.config.splits,
             random_seed=self.config.random_seed,
+            iteration_type=self.config.iteration_type,
         )
 
         best_val_loss = float("inf")

--- a/tests/data/test_datasource.py
+++ b/tests/data/test_datasource.py
@@ -40,7 +40,12 @@ def test_hf_datasource_from_file(dummy_text_file, simple_tokenizer):
     data_source = HFDataSource(path_or_name=str(dummy_text_file))
 
     train_loader, val_loader = data_source.get_dataloaders(
-        tokenizer=simple_tokenizer, block_size=block_size, batch_size=batch_size, splits=(0.5, 0.5), random_seed=42
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.5, 0.5),
+        random_seed=42,
+        iteration_type="chunking",
     )
 
     assert isinstance(train_loader, DataLoader)
@@ -70,6 +75,7 @@ def test_hf_datasource_from_directory(dummy_text_dir, simple_tokenizer):
         batch_size=batch_size,
         splits=(1.0, 0.0),  # Use all data for training
         random_seed=42,
+        iteration_type="chunking",
     )
 
     # 32 chars // (7+1) chunk size = 4 total samples.
@@ -91,6 +97,7 @@ def test_hf_datasource_streaming_from_file(dummy_text_file, simple_tokenizer):
         batch_size=batch_size,
         splits=(0.8, 0.2),  # Splits are ignored for streaming
         random_seed=42,
+        iteration_type="chunking",
     )
 
     assert isinstance(train_loader, DataLoader)
@@ -100,3 +107,176 @@ def test_hf_datasource_streaming_from_file(dummy_text_file, simple_tokenizer):
     train_batch = next(iter(train_loader))
     assert train_batch["input_ids"].shape == (batch_size, block_size)
     assert torch.equal(train_batch["input_ids"][0, 1:], train_batch["labels"][0, :-1])
+
+
+@pytest.fixture
+def multiline_text_file(tmp_path: Path) -> Path:
+    """Creates a text file with multiple lines for proper splitting."""
+    data_path = tmp_path / "multiline.txt"
+    # Each line becomes a separate sample in the dataset
+    data_path.write_text(
+        "0123456789abcdef\n"
+        "0123456789abcdef\n"
+        "0123456789abcdef\n"
+        "0123456789abcdef"
+    )
+    return data_path
+
+
+def test_hf_datasource_sliding_from_file(multiline_text_file, simple_tokenizer):
+    """Tests loading a dataset with sliding window from a multi-line text file."""
+    block_size = 7
+    batch_size = 4
+
+    data_source = HFDataSource(path_or_name=str(multiline_text_file))
+
+    train_loader, val_loader = data_source.get_dataloaders(
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.75, 0.25),  # 3 train lines, 1 val line
+        random_seed=42,
+        iteration_type="sliding",
+    )
+
+    assert isinstance(train_loader, DataLoader)
+    assert isinstance(val_loader, DataLoader)
+
+    # Each line has 16 tokens, so:
+    # Train: 3 lines * (16-7) = 27 sliding windows
+    # Val: 1 line * (16-7) = 9 sliding windows
+    train_samples = sum(len(batch["input_ids"]) for batch in train_loader)
+    val_samples = sum(len(batch["input_ids"]) for batch in val_loader)
+
+    # The exact split might vary due to randomization
+    assert train_samples > 0
+    assert val_samples > 0
+
+    train_batch = next(iter(train_loader))
+    assert train_batch["input_ids"].shape[1] == block_size
+    assert train_batch["labels"].shape[1] == block_size
+
+
+def test_hf_datasource_sliding_from_directory(tmp_path, simple_tokenizer):
+    """Tests loading a dataset with sliding window from a directory."""
+    # Create directory with multiple files (each becomes a sample)
+    data_dir = tmp_path / "multi_files"
+    data_dir.mkdir()
+    (data_dir / "a.txt").write_text("0123456789abcdef")
+    (data_dir / "b.txt").write_text("0123456789abcdef")
+    (data_dir / "c.txt").write_text("0123456789abcdef")
+    (data_dir / "d.txt").write_text("0123456789abcdef")
+
+    block_size = 10
+    batch_size = 5
+
+    data_source = HFDataSource(path_or_name=str(data_dir))
+
+    train_loader, val_loader = data_source.get_dataloaders(
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.75, 0.25),  # 3 train files, 1 val file
+        random_seed=42,
+        iteration_type="sliding",
+    )
+
+    assert isinstance(train_loader, DataLoader)
+    assert isinstance(val_loader, DataLoader)
+
+    train_batch = next(iter(train_loader))
+    assert train_batch["input_ids"].shape[1] == block_size
+    assert train_batch["labels"].shape[1] == block_size
+
+
+def test_sliding_window_overlap(multiline_text_file, simple_tokenizer):
+    """Tests that sliding windows actually overlap as expected."""
+    block_size = 5
+    batch_size = 2
+
+    data_source = HFDataSource(path_or_name=str(multiline_text_file))
+
+    train_loader, val_loader = data_source.get_dataloaders(
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.75, 0.25),  # Valid split for 4 lines
+        random_seed=42,
+        iteration_type="sliding",
+    )
+
+    # Check within a batch that the sliding window property holds
+    train_batch = next(iter(train_loader))
+
+    # Each sample in the batch should have correct shape
+    assert train_batch["input_ids"].shape[1] == block_size
+    assert train_batch["labels"].shape[1] == block_size
+
+    # Labels should be input shifted by 1 position
+    for i in range(len(train_batch["input_ids"])):
+        # The relationship between input and labels in the same window
+        input_ids = train_batch["input_ids"][i]
+        labels = train_batch["labels"][i]
+        # labels[j] should predict input_ids[j+1]
+        assert torch.equal(input_ids[1:], labels[:-1])
+
+
+def test_hf_datasource_streaming_sliding_raises_error(dummy_text_file, simple_tokenizer):
+    """Tests that sliding window with streaming dataset raises an error."""
+    block_size = 7
+    batch_size = 2
+
+    data_source = HFDataSource(path_or_name=str(dummy_text_file), streaming=True)
+
+    with pytest.raises(ValueError, match="Sliding not supported for streaming dataset"):
+        data_source.get_dataloaders(
+            tokenizer=simple_tokenizer,
+            block_size=block_size,
+            batch_size=batch_size,
+            splits=(0.8, 0.2),
+            random_seed=42,
+            iteration_type="sliding",
+        )
+
+
+def test_sliding_vs_chunking_sample_count(multiline_text_file, simple_tokenizer):
+    """Tests that sliding produces more samples than chunking."""
+    block_size = 8
+    batch_size = 100  # Large batch to get all samples
+
+    data_source = HFDataSource(path_or_name=str(multiline_text_file))
+
+    # Get chunking results - use a valid split
+    chunk_train, chunk_val = data_source.get_dataloaders(
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.75, 0.25),
+        random_seed=42,
+        iteration_type="chunking",
+    )
+
+    # Get sliding results with same split
+    slide_train, slide_val = data_source.get_dataloaders(
+        tokenizer=simple_tokenizer,
+        block_size=block_size,
+        batch_size=batch_size,
+        splits=(0.75, 0.25),
+        random_seed=42,
+        iteration_type="sliding",
+    )
+
+    # Count total samples in each
+    chunk_samples = sum(len(batch["input_ids"]) for batch in chunk_train)
+    slide_samples = sum(len(batch["input_ids"]) for batch in slide_train)
+
+    # Sliding should produce many more samples than chunking
+    # Chunking: non-overlapping blocks
+    # Sliding: overlapping windows (one per position)
+    assert slide_samples > chunk_samples
+
+    # Verify the shapes are consistent
+    chunk_batch = next(iter(chunk_train))
+    slide_batch = next(iter(slide_train))
+    assert chunk_batch["input_ids"].shape[1] == block_size
+    assert slide_batch["input_ids"].shape[1] == block_size

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "scratchgpt"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
# What does this PR do?
This PR introduces a sliding window iteration mode for dataset processing, providing an alternative to the existing chunking approach. Sliding windows create overlapping sequences that move by one token at a time, significantly increasing the number of training samples and improving context coverage.

# Details
- Add `iteration_type` parameter to training config with "chunking" or "sliding" options
- Implement `SlidingWindowDataset` class for creating overlapping token windows
- Update `HFDataSource` to handle both iteration modes via pattern matching
- Add comprehensive test suite covering sliding window functionality
- Sliding mode disabled for streaming datasets due to sequential constraints
- Bump version to 0.5.0 to reflect new feature addition

# Highlights
The key difference between iteration modes:
```python
# Chunking: Non-overlapping blocks
# Input: "0123456789" with block_size=3
# Samples: [012], [345], [678]

# Sliding: Overlapping windows (stride=1)  
# Input: "0123456789" with block_size=3
# Samples: [012], [123], [234], [345], [456], [567], [678]
```

# Usage in config:
```python
training = ScratchGPTTraining(
    iteration_type="sliding",  # or "chunking" (default)
    # ... other params
)
```